### PR TITLE
Introduce general CSS selector for fixes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.0.1 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce general CSS-selectors for fixes [Kevin Bieri]
 
 
 1.0.0 (2017-03-29)

--- a/ftw/iframefix/resources/scss/iefixes.scss
+++ b/ftw/iframefix/resources/scss/iefixes.scss
@@ -7,15 +7,15 @@
   IE10 and older MS browsers don't know pointer-events, so this selector won't work for them.
 */
 
-@include ie-only(".sl-can-edit .ftw-simplelayout-videoblock .sl-block-content") {
+@include ie-only(".fix-iframe-ie-hover") {
   cursor: not-allowed;
 }
-@include ie-only(".sl-can-edit .ftw-simplelayout-videoblock .sl-block-content iframe") {
+@include ie-only(".fix-iframe-ie-hover") {
   pointer-events: none;
 }
-@include ie-only(".sl-can-edit .ftw-iframeblock-iframeblock .sl-block-content") {
+@include ie-only(".fix-iframe-ie-hover") {
   cursor: not-allowed;
 }
-@include ie-only(".sl-can-edit .ftw-iframeblock-iframeblock iframe") {
+@include ie-only(".fix-iframe-ie-hover") {
   pointer-events: none;
 }


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.iframefix/issues/2

⚠️ Needs to be introduced in version `2.0.0` because these changes break the backwards compatibility.