### PR TITLE
Pick right version of ftw.theming.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Require ftw.theming 1.10.2. [Kevin Bieri]
+
 - Introduce general CSS-selectors for fixes [Kevin Bieri]
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Plone',
         'setuptools',
         'ftw.upgrade',
-        'ftw.theming',
+        'ftw.theming >= 1.10.2',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
See https://github.com/4teamwork/ftw.theming/pull/82

Version 1.10.2 of ftw.theming contains the `webkit-only` mixin which
is needed for the iframefix to work.