### PR TITLE
Provide mixins for various iframe fixes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Provide mixins for various fixes. [Kevin Bieri]
+
 - Require ftw.theming 1.10.2. [Kevin Bieri]
 
 - Introduce general CSS-selectors for fixes [Kevin Bieri]

--- a/ftw/iframefix/resources/resources.zcml
+++ b/ftw/iframefix/resources/resources.zcml
@@ -5,7 +5,7 @@
 
     <include package="ftw.theming" />
 
-    <theme:resources profile="ftw.iframefix:default" slot="addon">
+    <theme:resources profile="ftw.iframefix:default" slot="mixins">
         <theme:scss file="scss/iefixes.scss" />
         <theme:scss file="scss/webkitfixes.scss" />
     </theme:resources>

--- a/ftw/iframefix/resources/scss/iefixes.scss
+++ b/ftw/iframefix/resources/scss/iefixes.scss
@@ -7,15 +7,10 @@
   IE10 and older MS browsers don't know pointer-events, so this selector won't work for them.
 */
 
-@include ie-only(".fix-iframe-ie-hover") {
+@mixin fix-iframe-cursor() {
   cursor: not-allowed;
 }
-@include ie-only(".fix-iframe-ie-hover") {
-  pointer-events: none;
-}
-@include ie-only(".fix-iframe-ie-hover") {
-  cursor: not-allowed;
-}
-@include ie-only(".fix-iframe-ie-hover") {
+
+@mixin fix-iframe-hover() {
   pointer-events: none;
 }


### PR DESCRIPTION
We are more flexible when using mixins for iframe fixes.
In some cases it's impossible to put a class on an element to active the
iframefix.